### PR TITLE
Minimal changes to get it to work as shown in video

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -21,6 +21,7 @@ func main() {
 	}
 
 	router.Get("/", handler.Handler{Env: env, H: handler.Index})
+	router.Get("/blog", handler.Handler{Env: env, H: handler.Blog})
 
 	log.Fatal(http.ListenAndServe(":8000", router))
 

--- a/handler/handler.go
+++ b/handler/handler.go
@@ -119,3 +119,12 @@ func Index(e *Env, w http.ResponseWriter, r *http.Request, ps httprouter.Params)
 	tmpl.ExecuteTemplate(w, "base", nil)
 	return nil
 }
+
+func Blog(e *Env, w http.ResponseWriter, r *http.Request, ps httprouter.Params) error {
+	lp := filepath.Join("templates", "base.html")
+	fp := filepath.Join("templates", "blog.html")
+
+	tmpl, _ := template.ParseFiles(lp, fp)
+	tmpl.ExecuteTemplate(w, "base", nil)
+	return nil
+}

--- a/templates/blog.html
+++ b/templates/blog.html
@@ -1,0 +1,4 @@
+{{define "title"}}Blog{{end}}
+{{define "body"}}
+<my-blog></my-blog>
+{{end}}

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,4 +1,4 @@
-{{define "title"}}A templated page{{end}} {{define "body"}}
+{{define "title"}}A templated page{{end}}
+{{define "body"}}
 <my-app name="Mitchell">App</my-app>
-<my-blog></my-blog>
 {{end}}


### PR DESCRIPTION
Thanks a bunch for your video, Mitch. I'd been trying to find a good way to get Go and Svelte to play nicely together for the better part of a day. Your video has the answer!

I found your linked repo though, and it seems to be a commit or two behind the version you showed in the video. It also doesn't quite work! Mainly, `localhost:8000/blog` doesn't open, and it's clear some files are missing. I made as few changes as I could, while still getting it to work.

Although, if you still have the version you were working with in the video handy, you might end up pushing that instead. As there seem to be other differences between what you showed there and the current pushed repo.

For instance, in the video under `handler.go > Index` you have:

```
func Index(e *Env, w http.ResponseWriter, r *http.Request, ps httprouter.Params) error {
	base := filepath.Join("templates", "base.html")
	index := filepath.Join("templates", "index.html")
```

Whereas, in the repo you have:
```
func Index(e *Env, w http.ResponseWriter, r *http.Request, ps httprouter.Params) error {
	lp := filepath.Join("templates", "base.html")
	fp := filepath.Join("templates", "index.html")
```

I didn't change these little differences to match the video since it doesn't break anything, but just letting you know in case you'd like to!